### PR TITLE
renew & add api gateway security

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -38,59 +38,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/NFT"
+              $ref: "#/components/schemas/MintNFT"
         description: NFT object to mint.
         required: true
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiResponse"
-        "400":
-          description: Invalid input
-  /nfts/transfer:
-    post:
-      tags:
-        - transfer
-      summary: Transfer the NFT.
-      operationId: transfer
-      parameters:
-        - name: tokenId
-          in: query
-          description: TokenID of the NFT to transfer.
-          required: true
-          schema:
-            type: string
-        - name: toAddress
-          in: query
-          description: Ethereum address to transfer the NFT to.
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiResponse"
-        "400":
-          description: Invalid input
-  /nfts/burn:
-    post:
-      tags:
-        - burn
-      summary: Burn the NFT.
-      operationId: burn
-      parameters:
-        - name: tokenId
-          in: query
-          description: TokenID of the NFT to burn.
-          required: true
-          schema:
-            type: string
       responses:
         "200":
           description: Success
@@ -145,20 +95,14 @@ paths:
           description: Invalid input
 servers:
   - url: /v1
+securityDefinitions:
+  api_key:
+    type: "apiKey"
+    name: "key"
+    in: "query"
+security:
+  - api_key: []
 components:
-  securitySchemes:
-    petstore_auth:
-      type: oauth2
-      flows:
-        implicit:
-          authorizationUrl: http://petstore.swagger.io/oauth/dialog
-          scopes:
-            write:pets: modify pets in your account
-            read:pets: read your pets
-    api_key:
-      type: apiKey
-      name: api_key
-      in: header
   schemas:
     NFT:
       type: object
@@ -167,12 +111,12 @@ components:
           type: integer
           format: int64
           minimum: 1
-        name:
+        tokenUri:
           type: string
-          description: A name for the NFT.
-        description:
-          type: string
-          description: A description for the NFT.
+          description: A Metadata URI.
+    MintNFT:
+      type: object
+      properties:
         tokenUri:
           type: string
           description: A Metadata URI.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6,13 +6,19 @@ tags:
   - name: NFT
     description: Manage NFTs
 paths:
-  /nfts/{tokenId}:
+  /nfts/{contractId}/{tokenId}:
     get:
       tags:
         - get nft
       summary: Get information of the NFT.
       operationId: getNFT
       parameters:
+        - in: path
+          name: contractId
+          required: true
+          description: Target contract ID.
+          schema:
+            type: string
         - in: path
           name: tokenId
           required: true
@@ -28,12 +34,19 @@ paths:
                 $ref: "#/components/schemas/NFT"
         "400":
           description: Invalid input
-  /nfts/mint:
+  /nfts/{contractId}/mint:
     post:
       tags:
         - mint
       summary: Mint a new NFT.
       operationId: mint
+      parameters:
+        - in: path
+          name: contractId
+          required: true
+          description: Target contract ID.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -50,15 +63,21 @@ paths:
                 $ref: "#/components/schemas/ApiResponse"
         "400":
           description: Invalid input
-  /nfts/royalty:
+  /nfts/{contractId}/{tokenId}/royalty:
     get:
       tags:
         - royalty
       summary: Get royalty of the NFT.
       operationId: getRoyalty
       parameters:
-        - name: tokenId
-          in: query
+        - in: path
+          name: contractId
+          required: true
+          description: Target contract ID.
+          schema:
+            type: string
+        - in: path
+          name: tokenId
           description: TokenID to get royalty.
           required: true
           schema:
@@ -77,6 +96,19 @@ paths:
         - royalty
       summary: Set royalty to the NFT.
       operationId: setRoyalty
+      parameters:
+        - in: path
+          name: contractId
+          required: true
+          description: Target contract ID.
+          schema:
+            type: string
+        - in: path
+          name: tokenId
+          required: true
+          description: Target token ID.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
## 関連リンク(Slack, Notion)や GitHub Issue
https://github.com/0xhokusai/hokusai-api-data-provider/pull/8#discussion_r680506314

## やったこと
- API Gatewayで使うapi_Keyの追加
https://cloud.google.com/endpoints/docs/openapi/restricting-api-access-with-api-keys?hl=ja#calling_an_api_using_an_api_key
- Mint, Royalty以外の削除

## やらないこと


## 動作確認


## その他

レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）